### PR TITLE
Added support for enriching the Completed Operation log event

### DIFF
--- a/src/SerilogTimings/Operation.cs
+++ b/src/SerilogTimings/Operation.cs
@@ -20,6 +20,7 @@ using Serilog.Context;
 using Serilog.Events;
 using SerilogTimings.Extensions;
 using SerilogTimings.Configuration;
+using Serilog.Core;
 
 namespace SerilogTimings
 {
@@ -145,6 +146,20 @@ namespace SerilogTimings
                 return;
 
             Write(_target.ForContext(resultPropertyName, result, destructureObjects), _completionLevel, OutcomeCompleted);
+        }
+
+        /// <summary>
+        /// Complete the timed operation and enriches the log event with the provided enrichers.
+        /// </summary>
+        /// <param name="resultEnrichers">Enrichers that applied to the final log event.</param>
+        public void Complete(params ILogEventEnricher[] resultEnrichers)
+        {
+            if (resultEnrichers == null) throw new ArgumentNullException(nameof(resultEnrichers));
+
+            if (_completionBehaviour == CompletionBehaviour.Silent)
+                return;
+
+            Write(_target.ForContext(resultEnrichers), _completionLevel, OutcomeCompleted);
         }
 
         /// <summary>

--- a/test/SerilogTimings.Tests/OperationTests.cs
+++ b/test/SerilogTimings.Tests/OperationTests.cs
@@ -4,6 +4,7 @@ using Serilog.Events;
 using SerilogTimings.Extensions;
 using SerilogTimings.Tests.Support;
 using Xunit;
+using Serilog.Core.Enrichers;
 
 namespace SerilogTimings.Tests
 {
@@ -53,6 +54,19 @@ namespace SerilogTimings.Tests
             op.Complete("Value", 42);
             Assert.Equal(1, logger.Events.Count);
             Assert.True(logger.Events.Single().Properties.ContainsKey("Value"));
+        }
+
+        [Fact]
+        public void CompleteEnrichesLogEvent()
+        {
+            var logger = new CollectingLogger();
+            var op = logger.Logger.BeginOperation("Test");
+            op.Complete(new PropertyEnricher("Value", 1), new PropertyEnricher("Value2", 2));
+
+            Assert.Equal(1, logger.Events.Count);
+            var logEvent = logger.Events.Single();
+            Assert.True(logEvent.Properties.ContainsKey("Value"));
+            Assert.True(logEvent.Properties.ContainsKey("Value2"));
         }
 
         [Fact]


### PR DESCRIPTION
Ref #8.

This update allows one or more `LogEventEnricher` instances to be passed to `Operation.Complete` in order to enrich the final log event.

An example of where this can be used is logging the input parameters and response content in a Web API action filter.

During `ActionExecuting` we begin the operation and enrich it with properties from the input parameters. It is then stored in `HttpRequestMessage.Properties`.

During `ActionExecuted` we obtain the `Operation` and call `Complete` enriching it with properties from `HttpResponseMessage.Content`.
