### PR TITLE
Fixes #17. Add support for dynamic log levels determined at run-time

### DIFF
--- a/src/SerilogTimings/Extensions/LoggerOperationExtensions.cs
+++ b/src/SerilogTimings/Extensions/LoggerOperationExtensions.cs
@@ -52,6 +52,30 @@ namespace SerilogTimings.Extensions
         }
 
         /// <summary>
+        /// Begin a new timed operation. The return value must be completed using <see cref="Operation.Complete()"/>,
+        /// or disposed to record abandonment.
+        /// </summary>
+        /// <param name="logger">The logger through which the timing will be recorded.</param>
+        /// <param name="dynamicCompletionLevel">A <see cref="Func{Operation, LogEventLevel}"/> that is lazily evaluated to determine the log event level. Useful in evaluating <see cref="Operation.Elapsed"/> to determine the log event level at run-time.</param>
+        /// <param name="dynamicAbandonmentLevel">A <see cref="Func{Operation, LogEventLevel}"/> that is lazily evaluated to determine the log event level. Useful in evaluating <see cref="Operation.Elapsed"/> to determine the log event level at run-time.</param>
+        /// <param name="messageTemplate">A log message describing the operation, in message template format.</param>
+        /// <param name="args">Arguments to the log message. These will be stored and captured only when the
+        /// operation completes, so do not pass arguments that are mutated during the operation.</param>
+        /// <returns>An <see cref="Operation"/> object.</returns>
+        public static Operation BeginOperation(this ILogger logger, Func<Operation, LogEventLevel> dynamicCompletionLevel, Func<Operation, LogEventLevel> dynamicAbandonmentLevel, string messageTemplate, params object[] args)
+        {
+            if (dynamicCompletionLevel == null)
+            {
+                dynamicCompletionLevel = operation => LogEventLevel.Information;
+            }
+            if (dynamicAbandonmentLevel == null)
+            {
+                dynamicAbandonmentLevel = operation => LogEventLevel.Warning;
+            }
+            return new Operation(logger, messageTemplate, args, CompletionBehaviour.Abandon, dynamicCompletionLevel, dynamicAbandonmentLevel);
+        }
+
+        /// <summary>
         /// Configure the logging levels used for completion and abandonment events.
         /// </summary>
         /// <param name="logger">The logger through which the timing will be recorded.</param>

--- a/src/SerilogTimings/Operation.cs
+++ b/src/SerilogTimings/Operation.cs
@@ -63,10 +63,15 @@ namespace SerilogTimings
 
         IDisposable _popContext;
         CompletionBehaviour _completionBehaviour;
-        readonly LogEventLevel _completionLevel;
-        readonly LogEventLevel _abandonmentLevel;
+        readonly Lazy<LogEventLevel> _completionLevel;
+        readonly Lazy<LogEventLevel> _abandonmentLevel;
 
         internal Operation(ILogger target, string messageTemplate, object[] args, CompletionBehaviour completionBehaviour, LogEventLevel completionLevel, LogEventLevel abandonmentLevel)
+            : this(target, messageTemplate, args, completionBehaviour, operation => completionLevel, operation => abandonmentLevel)
+        {
+        }
+
+        internal Operation(ILogger target, string messageTemplate, object[] args, CompletionBehaviour completionBehaviour, Func<Operation, LogEventLevel> completionLevel, Func<Operation, LogEventLevel> abandonmentLevel)
         {
             if (target == null) throw new ArgumentNullException(nameof(target));
             if (messageTemplate == null) throw new ArgumentNullException(nameof(messageTemplate));
@@ -75,8 +80,8 @@ namespace SerilogTimings
             _messageTemplate = messageTemplate;
             _args = args;
             _completionBehaviour = completionBehaviour;
-            _completionLevel = completionLevel;
-            _abandonmentLevel = abandonmentLevel;
+            _completionLevel = new Lazy<LogEventLevel>(() => completionLevel(this));
+            _abandonmentLevel = new Lazy<LogEventLevel>(() => abandonmentLevel(this));
             _popContext = LogContext.PushProperty(nameof(Properties.OperationId), Guid.NewGuid());
             _stopwatch = Stopwatch.StartNew();
         }
@@ -194,13 +199,13 @@ namespace SerilogTimings
             _popContext = null;
         }
 
-        void Write(ILogger target, LogEventLevel level, string outcome)
+        void Write(ILogger target, Lazy<LogEventLevel> level, string outcome)
         {
             _completionBehaviour = CompletionBehaviour.Silent;
 
             var elapsed = _stopwatch.Elapsed.TotalMilliseconds;
 
-            target.Write(level, $"{_messageTemplate} {{{nameof(Properties.Outcome)}}} in {{{nameof(Properties.Elapsed)}:0.0}} ms", _args.Concat(new object[] { outcome, elapsed }).ToArray());
+            target.Write(level.Value, $"{_messageTemplate} {{{nameof(Properties.Outcome)}}} in {{{nameof(Properties.Elapsed)}:0.0}} ms", _args.Concat(new object[] { outcome, elapsed }).ToArray());
         }
     }
 }

--- a/src/SerilogTimings/Operation.cs
+++ b/src/SerilogTimings/Operation.cs
@@ -164,7 +164,6 @@ namespace SerilogTimings
         {
             _stopwatch.Stop();
             _completionBehaviour = CompletionBehaviour.Silent;
-            PopLogContext();
         }
 
         /// <summary>
@@ -191,11 +190,6 @@ namespace SerilogTimings
                     throw new InvalidOperationException("Unknown underlying state value");
             }
 
-            PopLogContext();
-        }
-
-        void PopLogContext()
-        {
             _popContext?.Dispose();
             _popContext = null;
         }
@@ -207,8 +201,6 @@ namespace SerilogTimings
             var elapsed = _stopwatch.Elapsed.TotalMilliseconds;
 
             target.Write(level, $"{_messageTemplate} {{{nameof(Properties.Outcome)}}} in {{{nameof(Properties.Elapsed)}:0.0}} ms", _args.Concat(new object[] { outcome, elapsed }).ToArray());
-
-            PopLogContext();
         }
     }
 }

--- a/src/SerilogTimings/Operation.cs
+++ b/src/SerilogTimings/Operation.cs
@@ -23,192 +23,192 @@ using SerilogTimings.Configuration;
 
 namespace SerilogTimings
 {
-	/// <summary>
-	/// Records operation timings to the Serilog log.
-	/// </summary>
-	/// <remarks>
-	/// Static members on this class are thread-safe. Instances
-	/// of <see cref="Operation"/> are designed for use on a single thread only.
-	/// </remarks>
-	public class Operation : IDisposable
-	{
-		/// <summary>
-		/// Property names attached to events by <see cref="Operation"/>s.
-		/// </summary>
-		public enum Properties
-		{
-			/// <summary>
-			/// The timing, in milliseconds.
-			/// </summary>
-			Elapsed,
+    /// <summary>
+    /// Records operation timings to the Serilog log.
+    /// </summary>
+    /// <remarks>
+    /// Static members on this class are thread-safe. Instances
+    /// of <see cref="Operation"/> are designed for use on a single thread only.
+    /// </remarks>
+    public class Operation : IDisposable
+    {
+        /// <summary>
+        /// Property names attached to events by <see cref="Operation"/>s.
+        /// </summary>
+        public enum Properties
+        {
+            /// <summary>
+            /// The timing, in milliseconds.
+            /// </summary>
+            Elapsed,
 
-			/// <summary>
-			/// Completion status, either <em>completed</em> or <em>discarded</em>.
-			/// </summary>
-			Outcome,
+            /// <summary>
+            /// Completion status, either <em>completed</em> or <em>discarded</em>.
+            /// </summary>
+            Outcome,
 
-			/// <summary>
-			/// A unique identifier added to the log context during
-			/// the operation.
-			/// </summary>
-			OperationId
-		};
+            /// <summary>
+            /// A unique identifier added to the log context during
+            /// the operation.
+            /// </summary>
+            OperationId
+        };
 
-		const string OutcomeCompleted = "completed", OutcomeAbandoned = "abandoned";
+        const string OutcomeCompleted = "completed", OutcomeAbandoned = "abandoned";
 
-		readonly ILogger _target;
-		readonly string _messageTemplate;
-		readonly object[] _args;
-		readonly Stopwatch _stopwatch;
+        readonly ILogger _target;
+        readonly string _messageTemplate;
+        readonly object[] _args;
+        readonly Stopwatch _stopwatch;
 
-		IDisposable _popContext;
-		CompletionBehaviour _completionBehaviour;
-		readonly LogEventLevel _completionLevel;
-		readonly LogEventLevel _abandonmentLevel;
+        IDisposable _popContext;
+        CompletionBehaviour _completionBehaviour;
+        readonly LogEventLevel _completionLevel;
+        readonly LogEventLevel _abandonmentLevel;
 
-		internal Operation(ILogger target, string messageTemplate, object[] args, CompletionBehaviour completionBehaviour, LogEventLevel completionLevel, LogEventLevel abandonmentLevel)
-		{
-			if (target == null) throw new ArgumentNullException(nameof(target));
-			if (messageTemplate == null) throw new ArgumentNullException(nameof(messageTemplate));
-			if (args == null) throw new ArgumentNullException(nameof(args));
-			_target = target;
-			_messageTemplate = messageTemplate;
-			_args = args;
-			_completionBehaviour = completionBehaviour;
-			_completionLevel = completionLevel;
-			_abandonmentLevel = abandonmentLevel;
-			_popContext = LogContext.PushProperty(nameof(Properties.OperationId), Guid.NewGuid());
-			_stopwatch = Stopwatch.StartNew();
-		}
+        internal Operation(ILogger target, string messageTemplate, object[] args, CompletionBehaviour completionBehaviour, LogEventLevel completionLevel, LogEventLevel abandonmentLevel)
+        {
+            if (target == null) throw new ArgumentNullException(nameof(target));
+            if (messageTemplate == null) throw new ArgumentNullException(nameof(messageTemplate));
+            if (args == null) throw new ArgumentNullException(nameof(args));
+            _target = target;
+            _messageTemplate = messageTemplate;
+            _args = args;
+            _completionBehaviour = completionBehaviour;
+            _completionLevel = completionLevel;
+            _abandonmentLevel = abandonmentLevel;
+            _popContext = LogContext.PushProperty(nameof(Properties.OperationId), Guid.NewGuid());
+            _stopwatch = Stopwatch.StartNew();
+        }
 
-		/// <summary>
-		/// Returns the elapsed time of the operation as a <see cref="TimeSpan"/>
-		/// </summary>
-		public TimeSpan Elapsed => _stopwatch.Elapsed;
+        /// <summary>
+        /// Returns the elapsed time of the operation as a <see cref="TimeSpan"/>
+        /// </summary>
+        public TimeSpan Elapsed => _stopwatch.Elapsed;
 
-		/// <summary>
-		/// Begin a new timed operation. The return value must be completed using <see cref="Complete()"/>,
-		/// or disposed to record abandonment.
-		/// </summary>
-		/// <param name="messageTemplate">A log message describing the operation, in message template format.</param>
-		/// <param name="args">Arguments to the log message. These will be stored and captured only when the
-		/// operation completes, so do not pass arguments that are mutated during the operation.</param>
-		/// <returns>An <see cref="Operation"/> object.</returns>
-		public static Operation Begin(string messageTemplate, params object[] args)
-		{
-			return Log.Logger.BeginOperation(messageTemplate, args);
-		}
+        /// <summary>
+        /// Begin a new timed operation. The return value must be completed using <see cref="Complete()"/>,
+        /// or disposed to record abandonment.
+        /// </summary>
+        /// <param name="messageTemplate">A log message describing the operation, in message template format.</param>
+        /// <param name="args">Arguments to the log message. These will be stored and captured only when the
+        /// operation completes, so do not pass arguments that are mutated during the operation.</param>
+        /// <returns>An <see cref="Operation"/> object.</returns>
+        public static Operation Begin(string messageTemplate, params object[] args)
+        {
+            return Log.Logger.BeginOperation(messageTemplate, args);
+        }
 
-		/// <summary>
-		/// Begin a new timed operation. The return value must be disposed to complete the operation.
-		/// </summary>
-		/// <param name="messageTemplate">A log message describing the operation, in message template format.</param>
-		/// <param name="args">Arguments to the log message. These will be stored and captured only when the
-		/// operation completes, so do not pass arguments that are mutated during the operation.</param>
-		/// <returns>An <see cref="Operation"/> object.</returns>
-		public static IDisposable Time(string messageTemplate, params object[] args)
-		{
-			return Log.Logger.TimeOperation(messageTemplate, args);
-		}
+        /// <summary>
+        /// Begin a new timed operation. The return value must be disposed to complete the operation.
+        /// </summary>
+        /// <param name="messageTemplate">A log message describing the operation, in message template format.</param>
+        /// <param name="args">Arguments to the log message. These will be stored and captured only when the
+        /// operation completes, so do not pass arguments that are mutated during the operation.</param>
+        /// <returns>An <see cref="Operation"/> object.</returns>
+        public static IDisposable Time(string messageTemplate, params object[] args)
+        {
+            return Log.Logger.TimeOperation(messageTemplate, args);
+        }
 
-		/// <summary>
-		/// Configure the logging levels used for completion and abandonment events.
-		/// </summary>
-		/// <param name="completion">The level of the event to write on operation completion.</param>
-		/// <param name="abandonment">The level of the event to write on operation abandonment; if not
-		/// specified, the <paramref name="completion"/> level will be used.</param>
-		/// <returns>An object from which timings with the configured levels can be made.</returns>
-		/// <remarks>If neither <paramref name="completion"/> nor <paramref name="abandonment"/> is enabled
-		/// on the logger at the time of the call, a no-op result is returned.</remarks>
-		public static LevelledOperation At(LogEventLevel completion, LogEventLevel? abandonment = null)
-		{
-			return Log.Logger.OperationAt(completion, abandonment);
-		}
+        /// <summary>
+        /// Configure the logging levels used for completion and abandonment events.
+        /// </summary>
+        /// <param name="completion">The level of the event to write on operation completion.</param>
+        /// <param name="abandonment">The level of the event to write on operation abandonment; if not
+        /// specified, the <paramref name="completion"/> level will be used.</param>
+        /// <returns>An object from which timings with the configured levels can be made.</returns>
+        /// <remarks>If neither <paramref name="completion"/> nor <paramref name="abandonment"/> is enabled
+        /// on the logger at the time of the call, a no-op result is returned.</remarks>
+        public static LevelledOperation At(LogEventLevel completion, LogEventLevel? abandonment = null)
+        {
+            return Log.Logger.OperationAt(completion, abandonment);
+        }
 
-		/// <summary>
-		/// Complete the timed operation. This will write the event and elapsed time to the log.
-		/// </summary>
-		public void Complete()
-		{
-			_stopwatch.Stop();
+        /// <summary>
+        /// Complete the timed operation. This will write the event and elapsed time to the log.
+        /// </summary>
+        public void Complete()
+        {
+            _stopwatch.Stop();
 
-			if (_completionBehaviour == CompletionBehaviour.Silent)
-				return;
+            if (_completionBehaviour == CompletionBehaviour.Silent)
+                return;
 
-			Write(_target, _completionLevel, OutcomeCompleted);
-		}
+            Write(_target, _completionLevel, OutcomeCompleted);
+        }
 
-		/// <summary>
-		/// Complete the timed operation with an included result value.
-		/// </summary>
-		/// <param name="resultPropertyName">The name for the property to attach to the event.</param>
-		/// <param name="result">The result value.</param>
-		/// <param name="destructureObjects">If true, the property value will be destructured (serialized).</param>
-		public void Complete(string resultPropertyName, object result, bool destructureObjects = false)
-		{
-			_stopwatch.Stop();
+        /// <summary>
+        /// Complete the timed operation with an included result value.
+        /// </summary>
+        /// <param name="resultPropertyName">The name for the property to attach to the event.</param>
+        /// <param name="result">The result value.</param>
+        /// <param name="destructureObjects">If true, the property value will be destructured (serialized).</param>
+        public void Complete(string resultPropertyName, object result, bool destructureObjects = false)
+        {
+            _stopwatch.Stop();
 
-			if (resultPropertyName == null) throw new ArgumentNullException(nameof(resultPropertyName));
+            if (resultPropertyName == null) throw new ArgumentNullException(nameof(resultPropertyName));
 
-			if (_completionBehaviour == CompletionBehaviour.Silent)
-				return;
+            if (_completionBehaviour == CompletionBehaviour.Silent)
+                return;
 
-			Write(_target.ForContext(resultPropertyName, result, destructureObjects), _completionLevel, OutcomeCompleted);
-		}
+            Write(_target.ForContext(resultPropertyName, result, destructureObjects), _completionLevel, OutcomeCompleted);
+        }
 
-		/// <summary>
-		/// Cancel the timed operation. After calling, no event will be recorded either through
-		/// completion or disposal.
-		/// </summary>
-		public void Cancel()
-		{
-			_stopwatch.Stop();
-			_completionBehaviour = CompletionBehaviour.Silent;
-			PopLogContext();
-		}
+        /// <summary>
+        /// Cancel the timed operation. After calling, no event will be recorded either through
+        /// completion or disposal.
+        /// </summary>
+        public void Cancel()
+        {
+            _stopwatch.Stop();
+            _completionBehaviour = CompletionBehaviour.Silent;
+            PopLogContext();
+        }
 
-		/// <summary>
-		/// Dispose the operation. If not already completed or canceled, an event will be written
-		/// with timing information. Operations started with <see cref="Time"/> will be completed through
-		/// disposal. Operations started with <see cref="Begin"/> will be recorded as abandoned.
-		/// </summary>
-		public void Dispose()
-		{
-			switch (_completionBehaviour)
-			{
-				case CompletionBehaviour.Silent:
-					break;
+        /// <summary>
+        /// Dispose the operation. If not already completed or canceled, an event will be written
+        /// with timing information. Operations started with <see cref="Time"/> will be completed through
+        /// disposal. Operations started with <see cref="Begin"/> will be recorded as abandoned.
+        /// </summary>
+        public void Dispose()
+        {
+            switch (_completionBehaviour)
+            {
+                case CompletionBehaviour.Silent:
+                    break;
 
-				case CompletionBehaviour.Abandon:
-					Write(_target, _abandonmentLevel, OutcomeAbandoned);
-					break;
+                case CompletionBehaviour.Abandon:
+                    Write(_target, _abandonmentLevel, OutcomeAbandoned);
+                    break;
 
-				case CompletionBehaviour.Complete:
-					Write(_target, _completionLevel, OutcomeCompleted);
-					break;
+                case CompletionBehaviour.Complete:
+                    Write(_target, _completionLevel, OutcomeCompleted);
+                    break;
 
-				default:
-					throw new InvalidOperationException("Unknown underlying state value");
-			}
+                default:
+                    throw new InvalidOperationException("Unknown underlying state value");
+            }
 
-			PopLogContext();
-		}
+            PopLogContext();
+        }
 
-		void PopLogContext()
-		{
-			_popContext?.Dispose();
-			_popContext = null;
-		}
+        void PopLogContext()
+        {
+            _popContext?.Dispose();
+            _popContext = null;
+        }
 
-		void Write(ILogger target, LogEventLevel level, string outcome)
-		{
-			_completionBehaviour = CompletionBehaviour.Silent;
+        void Write(ILogger target, LogEventLevel level, string outcome)
+        {
+            _completionBehaviour = CompletionBehaviour.Silent;
 
-			var elapsed = _stopwatch.Elapsed.TotalMilliseconds;
+            var elapsed = _stopwatch.Elapsed.TotalMilliseconds;
 
-			target.Write(level, $"{_messageTemplate} {{{nameof(Properties.Outcome)}}} in {{{nameof(Properties.Elapsed)}:0.0}} ms", _args.Concat(new object[] { outcome, elapsed }).ToArray());
+            target.Write(level, $"{_messageTemplate} {{{nameof(Properties.Outcome)}}} in {{{nameof(Properties.Elapsed)}:0.0}} ms", _args.Concat(new object[] { outcome, elapsed }).ToArray());
 
-			PopLogContext();
-		}
-	}
+            PopLogContext();
+        }
+    }
 }

--- a/src/SerilogTimings/Operation.cs
+++ b/src/SerilogTimings/Operation.cs
@@ -23,182 +23,192 @@ using SerilogTimings.Configuration;
 
 namespace SerilogTimings
 {
-    /// <summary>
-    /// Records operation timings to the Serilog log.
-    /// </summary>
-    /// <remarks>
-    /// Static members on this class are thread-safe. Instances
-    /// of <see cref="Operation"/> are designed for use on a single thread only.
-    /// </remarks>
-    public class Operation : IDisposable
-    {
-        /// <summary>
-        /// Property names attached to events by <see cref="Operation"/>s.
-        /// </summary>
-        public enum Properties
-        {
-            /// <summary>
-            /// The timing, in milliseconds.
-            /// </summary>
-            Elapsed,
+	/// <summary>
+	/// Records operation timings to the Serilog log.
+	/// </summary>
+	/// <remarks>
+	/// Static members on this class are thread-safe. Instances
+	/// of <see cref="Operation"/> are designed for use on a single thread only.
+	/// </remarks>
+	public class Operation : IDisposable
+	{
+		/// <summary>
+		/// Property names attached to events by <see cref="Operation"/>s.
+		/// </summary>
+		public enum Properties
+		{
+			/// <summary>
+			/// The timing, in milliseconds.
+			/// </summary>
+			Elapsed,
 
-            /// <summary>
-            /// Completion status, either <em>completed</em> or <em>discarded</em>.
-            /// </summary>
-            Outcome,
+			/// <summary>
+			/// Completion status, either <em>completed</em> or <em>discarded</em>.
+			/// </summary>
+			Outcome,
 
-            /// <summary>
-            /// A unique identifier added to the log context during
-            /// the operation.
-            /// </summary>
-            OperationId
-        };
+			/// <summary>
+			/// A unique identifier added to the log context during
+			/// the operation.
+			/// </summary>
+			OperationId
+		};
 
-        const string OutcomeCompleted = "completed", OutcomeAbandoned = "abandoned";
+		const string OutcomeCompleted = "completed", OutcomeAbandoned = "abandoned";
 
-        readonly ILogger _target;
-        readonly string _messageTemplate;
-        readonly object[] _args;
-        readonly Stopwatch _stopwatch;
+		readonly ILogger _target;
+		readonly string _messageTemplate;
+		readonly object[] _args;
+		readonly Stopwatch _stopwatch;
 
-        IDisposable _popContext;
-        CompletionBehaviour _completionBehaviour;
-        readonly LogEventLevel _completionLevel;
-        readonly LogEventLevel _abandonmentLevel;
+		IDisposable _popContext;
+		CompletionBehaviour _completionBehaviour;
+		readonly LogEventLevel _completionLevel;
+		readonly LogEventLevel _abandonmentLevel;
 
-        internal Operation(ILogger target, string messageTemplate, object[] args, CompletionBehaviour completionBehaviour, LogEventLevel completionLevel, LogEventLevel abandonmentLevel)
-        {
-            if (target == null) throw new ArgumentNullException(nameof(target));
-            if (messageTemplate == null) throw new ArgumentNullException(nameof(messageTemplate));
-            if (args == null) throw new ArgumentNullException(nameof(args));
-            _target = target;
-            _messageTemplate = messageTemplate;
-            _args = args;
-            _completionBehaviour = completionBehaviour;
-            _completionLevel = completionLevel;
-            _abandonmentLevel = abandonmentLevel;
-            _popContext = LogContext.PushProperty(nameof(Properties.OperationId), Guid.NewGuid());
-            _stopwatch = Stopwatch.StartNew();
-        }
+		internal Operation(ILogger target, string messageTemplate, object[] args, CompletionBehaviour completionBehaviour, LogEventLevel completionLevel, LogEventLevel abandonmentLevel)
+		{
+			if (target == null) throw new ArgumentNullException(nameof(target));
+			if (messageTemplate == null) throw new ArgumentNullException(nameof(messageTemplate));
+			if (args == null) throw new ArgumentNullException(nameof(args));
+			_target = target;
+			_messageTemplate = messageTemplate;
+			_args = args;
+			_completionBehaviour = completionBehaviour;
+			_completionLevel = completionLevel;
+			_abandonmentLevel = abandonmentLevel;
+			_popContext = LogContext.PushProperty(nameof(Properties.OperationId), Guid.NewGuid());
+			_stopwatch = Stopwatch.StartNew();
+		}
 
-        /// <summary>
-        /// Begin a new timed operation. The return value must be completed using <see cref="Complete()"/>,
-        /// or disposed to record abandonment.
-        /// </summary>
-        /// <param name="messageTemplate">A log message describing the operation, in message template format.</param>
-        /// <param name="args">Arguments to the log message. These will be stored and captured only when the
-        /// operation completes, so do not pass arguments that are mutated during the operation.</param>
-        /// <returns>An <see cref="Operation"/> object.</returns>
-        public static Operation Begin(string messageTemplate, params object[] args)
-        {
-            return Log.Logger.BeginOperation(messageTemplate, args);
-        }
+		/// <summary>
+		/// Returns the elapsed time of the operation as a <see cref="TimeSpan"/>
+		/// </summary>
+		public TimeSpan Elapsed => _stopwatch.Elapsed;
 
-        /// <summary>
-        /// Begin a new timed operation. The return value must be disposed to complete the operation.
-        /// </summary>
-        /// <param name="messageTemplate">A log message describing the operation, in message template format.</param>
-        /// <param name="args">Arguments to the log message. These will be stored and captured only when the
-        /// operation completes, so do not pass arguments that are mutated during the operation.</param>
-        /// <returns>An <see cref="Operation"/> object.</returns>
-        public static IDisposable Time(string messageTemplate, params object[] args)
-        {
-            return Log.Logger.TimeOperation(messageTemplate, args);
-        }
+		/// <summary>
+		/// Begin a new timed operation. The return value must be completed using <see cref="Complete()"/>,
+		/// or disposed to record abandonment.
+		/// </summary>
+		/// <param name="messageTemplate">A log message describing the operation, in message template format.</param>
+		/// <param name="args">Arguments to the log message. These will be stored and captured only when the
+		/// operation completes, so do not pass arguments that are mutated during the operation.</param>
+		/// <returns>An <see cref="Operation"/> object.</returns>
+		public static Operation Begin(string messageTemplate, params object[] args)
+		{
+			return Log.Logger.BeginOperation(messageTemplate, args);
+		}
 
-        /// <summary>
-        /// Configure the logging levels used for completion and abandonment events.
-        /// </summary>
-        /// <param name="completion">The level of the event to write on operation completion.</param>
-        /// <param name="abandonment">The level of the event to write on operation abandonment; if not
-        /// specified, the <paramref name="completion"/> level will be used.</param>
-        /// <returns>An object from which timings with the configured levels can be made.</returns>
-        /// <remarks>If neither <paramref name="completion"/> nor <paramref name="abandonment"/> is enabled
-        /// on the logger at the time of the call, a no-op result is returned.</remarks>
-        public static LevelledOperation At(LogEventLevel completion, LogEventLevel? abandonment = null)
-        {
-            return Log.Logger.OperationAt(completion, abandonment);
-        }
+		/// <summary>
+		/// Begin a new timed operation. The return value must be disposed to complete the operation.
+		/// </summary>
+		/// <param name="messageTemplate">A log message describing the operation, in message template format.</param>
+		/// <param name="args">Arguments to the log message. These will be stored and captured only when the
+		/// operation completes, so do not pass arguments that are mutated during the operation.</param>
+		/// <returns>An <see cref="Operation"/> object.</returns>
+		public static IDisposable Time(string messageTemplate, params object[] args)
+		{
+			return Log.Logger.TimeOperation(messageTemplate, args);
+		}
 
-        /// <summary>
-        /// Complete the timed operation. This will write the event and elapsed time to the log.
-        /// </summary>
-        public void Complete()
-        {
-            if (_completionBehaviour == CompletionBehaviour.Silent)
-                return;
+		/// <summary>
+		/// Configure the logging levels used for completion and abandonment events.
+		/// </summary>
+		/// <param name="completion">The level of the event to write on operation completion.</param>
+		/// <param name="abandonment">The level of the event to write on operation abandonment; if not
+		/// specified, the <paramref name="completion"/> level will be used.</param>
+		/// <returns>An object from which timings with the configured levels can be made.</returns>
+		/// <remarks>If neither <paramref name="completion"/> nor <paramref name="abandonment"/> is enabled
+		/// on the logger at the time of the call, a no-op result is returned.</remarks>
+		public static LevelledOperation At(LogEventLevel completion, LogEventLevel? abandonment = null)
+		{
+			return Log.Logger.OperationAt(completion, abandonment);
+		}
 
-            Write(_target, _completionLevel, OutcomeCompleted);
-        }
+		/// <summary>
+		/// Complete the timed operation. This will write the event and elapsed time to the log.
+		/// </summary>
+		public void Complete()
+		{
+			_stopwatch.Stop();
 
-        /// <summary>
-        /// Complete the timed operation with an included result value.
-        /// </summary>
-        /// <param name="resultPropertyName">The name for the property to attach to the event.</param>
-        /// <param name="result">The result value.</param>
-        /// <param name="destructureObjects">If true, the property value will be destructured (serialized).</param>
-        public void Complete(string resultPropertyName, object result, bool destructureObjects = false)
-        {
-            if (resultPropertyName == null) throw new ArgumentNullException(nameof(resultPropertyName));
+			if (_completionBehaviour == CompletionBehaviour.Silent)
+				return;
 
-            if (_completionBehaviour == CompletionBehaviour.Silent)
-                return;
+			Write(_target, _completionLevel, OutcomeCompleted);
+		}
 
-            Write(_target.ForContext(resultPropertyName, result, destructureObjects), _completionLevel, OutcomeCompleted);
-        }
+		/// <summary>
+		/// Complete the timed operation with an included result value.
+		/// </summary>
+		/// <param name="resultPropertyName">The name for the property to attach to the event.</param>
+		/// <param name="result">The result value.</param>
+		/// <param name="destructureObjects">If true, the property value will be destructured (serialized).</param>
+		public void Complete(string resultPropertyName, object result, bool destructureObjects = false)
+		{
+			_stopwatch.Stop();
 
-        /// <summary>
-        /// Cancel the timed operation. After calling, no event will be recorded either through
-        /// completion or disposal.
-        /// </summary>
-        public void Cancel()
-        {
-            _completionBehaviour = CompletionBehaviour.Silent;
-            PopLogContext();
-        }
+			if (resultPropertyName == null) throw new ArgumentNullException(nameof(resultPropertyName));
 
-        /// <summary>
-        /// Dispose the operation. If not already completed or canceled, an event will be written
-        /// with timing information. Operations started with <see cref="Time"/> will be completed through
-        /// disposal. Operations started with <see cref="Begin"/> will be recorded as abandoned.
-        /// </summary>
-        public void Dispose()
-        {
-            switch (_completionBehaviour)
-            {
-                case CompletionBehaviour.Silent:
-                    break;
+			if (_completionBehaviour == CompletionBehaviour.Silent)
+				return;
 
-                case CompletionBehaviour.Abandon:
-                    Write(_target, _abandonmentLevel, OutcomeAbandoned);
-                    break;
+			Write(_target.ForContext(resultPropertyName, result, destructureObjects), _completionLevel, OutcomeCompleted);
+		}
 
-                case CompletionBehaviour.Complete:
-                    Write(_target, _completionLevel, OutcomeCompleted);
-                    break;
+		/// <summary>
+		/// Cancel the timed operation. After calling, no event will be recorded either through
+		/// completion or disposal.
+		/// </summary>
+		public void Cancel()
+		{
+			_stopwatch.Stop();
+			_completionBehaviour = CompletionBehaviour.Silent;
+			PopLogContext();
+		}
 
-                default:
-                    throw new InvalidOperationException("Unknown underlying state value");
-            }
+		/// <summary>
+		/// Dispose the operation. If not already completed or canceled, an event will be written
+		/// with timing information. Operations started with <see cref="Time"/> will be completed through
+		/// disposal. Operations started with <see cref="Begin"/> will be recorded as abandoned.
+		/// </summary>
+		public void Dispose()
+		{
+			switch (_completionBehaviour)
+			{
+				case CompletionBehaviour.Silent:
+					break;
 
-            PopLogContext();
-        }
+				case CompletionBehaviour.Abandon:
+					Write(_target, _abandonmentLevel, OutcomeAbandoned);
+					break;
 
-        void PopLogContext()
-        {
-            _popContext?.Dispose();
-            _popContext = null;
-        }
+				case CompletionBehaviour.Complete:
+					Write(_target, _completionLevel, OutcomeCompleted);
+					break;
 
-        void Write(ILogger target, LogEventLevel level, string outcome)
-        {
-            _completionBehaviour = CompletionBehaviour.Silent;
+				default:
+					throw new InvalidOperationException("Unknown underlying state value");
+			}
 
-            var elapsed = _stopwatch.Elapsed.TotalMilliseconds;
+			PopLogContext();
+		}
 
-            target.Write(level, $"{_messageTemplate} {{{nameof(Properties.Outcome)}}} in {{{nameof(Properties.Elapsed)}:0.0}} ms", _args.Concat(new object[] {outcome, elapsed }).ToArray());
+		void PopLogContext()
+		{
+			_popContext?.Dispose();
+			_popContext = null;
+		}
 
-            PopLogContext();
-        }
-    }
+		void Write(ILogger target, LogEventLevel level, string outcome)
+		{
+			_completionBehaviour = CompletionBehaviour.Silent;
+
+			var elapsed = _stopwatch.Elapsed.TotalMilliseconds;
+
+			target.Write(level, $"{_messageTemplate} {{{nameof(Properties.Outcome)}}} in {{{nameof(Properties.Elapsed)}:0.0}} ms", _args.Concat(new object[] { outcome, elapsed }).ToArray());
+
+			PopLogContext();
+		}
+	}
 }

--- a/test/SerilogTimings.Tests/OperationTests.cs
+++ b/test/SerilogTimings.Tests/OperationTests.cs
@@ -1,14 +1,9 @@
 ﻿using System;
-using System.Diagnostics;
 using System.Linq;
 using System.Threading.Tasks;
-
 using Serilog;
 using Serilog.Events;
-
-using SerilogTimings;
 using SerilogTimings.Extensions;
-using SerilogTimings.Tests;
 using SerilogTimings.Tests.Support;
 using Xunit;
 


### PR DESCRIPTION
@pardahlman

This PR allows for dynamic log level which can be determined at run-time by evaluating `operation.Elapsed`.