### PR TITLE
Keep template arguments separated to ensure correctness of message

### DIFF
--- a/src/SerilogTimings/Operation.cs
+++ b/src/SerilogTimings/Operation.cs
@@ -196,7 +196,7 @@ namespace SerilogTimings
 
             var elapsed = _stopwatch.Elapsed.TotalMilliseconds;
 
-            target.Write(level, $"{_messageTemplate} {{{nameof(Properties.Outcome)}}} in {{{nameof(Properties.Elapsed)}:0.0}} ms", _args.Concat(new object[] {outcome, elapsed }).ToArray());
+            target.Write(level, $"{_messageTemplate} {{{nameof(Properties.Outcome)}}} in {{{nameof(Properties.Elapsed)}:0.0}} ms", _args, outcome, elapsed);
 
             PopLogContext();
         }

--- a/test/SerilogTimings.Tests/OperationTests.cs
+++ b/test/SerilogTimings.Tests/OperationTests.cs
@@ -10,6 +10,19 @@ namespace SerilogTimings.Tests
     public class OperationTests
     {
         [Fact]
+        public void TestForArrayAsParams()
+        {
+            var logger = new CollectingLogger();
+
+            var op = logger.Logger.TimeOperation("Test {Identifier}", new object[] { "a", "b" });
+            op.Dispose();
+
+            var messageText = logger.Events.First().RenderMessage();
+            Assert.True(messageText.StartsWith("Test [\"a\", \"b\"] \"completed\" in"));
+            Assert.True(messageText.EndsWith(" ms"));
+        }
+
+        [Fact]
         public void DisposeRecordsCompletionOfTimings()
         {
             var logger = new CollectingLogger();


### PR DESCRIPTION
This PR fixes #24 

Please note that I weren't able to test this with the current .xproj projects in dev.
Tested against converted .xproj to .csproj. The project conversion comes as a separate PR.