### PR TITLE
Re #8: adding arbitrary properties and exceptions to the operation

### DIFF
--- a/serilog-timings.sln.DotSettings
+++ b/serilog-timings.sln.DotSettings
@@ -1,0 +1,6 @@
+﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=destructure/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=destructured/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=enricher/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=enrichers/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=Serilog/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>

--- a/src/SerilogTimings/Operation.cs
+++ b/src/SerilogTimings/Operation.cs
@@ -13,10 +13,12 @@
 // limitations under the License.
 
 using System;
+using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
 using Serilog;
 using Serilog.Context;
+using Serilog.Core;
 using Serilog.Events;
 using SerilogTimings.Extensions;
 using SerilogTimings.Configuration;
@@ -56,7 +58,7 @@ namespace SerilogTimings
 
         const string OutcomeCompleted = "completed", OutcomeAbandoned = "abandoned";
 
-        readonly ILogger _target;
+        ILogger _target;
         readonly string _messageTemplate;
         readonly object[] _args;
         readonly Stopwatch _stopwatch;
@@ -199,6 +201,46 @@ namespace SerilogTimings
             target.Write(level, $"{_messageTemplate} {{{nameof(Properties.Outcome)}}} in {{{nameof(Properties.Elapsed)}:0.0}} ms", _args.Concat(new object[] {outcome, elapsed }).ToArray());
 
             PopLogContext();
+        }
+
+        /// <summary>
+        /// Enriches resulting log event via the provided enricher.
+        /// </summary>
+        /// <param name="enricher">Enricher that applies in the context.</param>
+        /// <returns>Same <see cref="Operation"/>.</returns>
+        /// <seealso cref="ILogger.ForContext(ILogEventEnricher)"/>
+        public Operation EnrichWith(ILogEventEnricher enricher)
+        {
+            _target = _target.ForContext(enricher);
+            return this;
+        }
+
+        /// <summary>
+        /// Enriches resulting log event via the provided enrichers.
+        /// </summary>
+        /// <param name="enrichers">Enrichers that apply in the context.</param>
+        /// <returns>A logger that will enrich log events as specified.</returns>
+        /// <returns>Same <see cref="Operation"/>.</returns>
+        /// <seealso cref="ILogger.ForContext(IEnumerable{ILogEventEnricher})"/>
+        public Operation EnrichWith(IEnumerable<ILogEventEnricher> enrichers)
+        {
+            _target = _target.ForContext(enrichers);
+            return this;
+        }
+
+        /// <summary>
+        /// Enriches resulting log event with the specified property.
+        /// </summary>
+        /// <param name="propertyName">The name of the property. Must be non-empty.</param>
+        /// <param name="value">The property value.</param>
+        /// <param name="destructureObjects">If true, the value will be serialized as a structured
+        /// object if possible; if false, the object will be recorded as a scalar or simple array.</param>
+        /// <returns>Same <see cref="Operation"/>.</returns>
+        /// <seealso cref="ILogger.ForContext(string,object,bool)"/>
+        public Operation EnrichWith(string propertyName, object value, bool destructureObjects = false)
+        {
+            _target = _target.ForContext(propertyName, value, destructureObjects);
+            return this;
         }
     }
 }

--- a/src/SerilogTimings/Operation.cs
+++ b/src/SerilogTimings/Operation.cs
@@ -16,7 +16,6 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
-using System.Runtime.InteropServices;
 using Serilog;
 using Serilog.Context;
 using Serilog.Core;

--- a/src/SerilogTimings/OperationExtensions.cs
+++ b/src/SerilogTimings/OperationExtensions.cs
@@ -1,0 +1,53 @@
+﻿// Copyright 2019 SerilogTimings Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
+
+namespace SerilogTimings
+{
+    /// <summary>
+    /// Exception-handling related helpers for <see cref="Operation"/>.
+    /// </summary>
+    public static class OperationExtensions
+    {
+        /// <summary>
+        /// Enriches resulting log event with the given exception and skips exception-handling block.
+        /// </summary>
+        /// <param name="operation">Operation to enrich with exception.</param>
+        /// <param name="exception">Exception related to the event.</param>
+        /// <returns><c>false</c></returns>
+        /// <seealso cref="Operation.SetException"/>
+        /// <example>
+        /// <code>
+        /// using (var op = Operation.Begin(...)
+        /// {
+        ///     try
+        ///     {
+        ///         //Do something
+        ///         op.Complete();
+        ///     }
+        ///     catch (Exception e) when (op.SetExceptionAndRethrow(e))
+        ///     {
+        ///         //this will never be called
+        ///     }
+        /// }
+        /// </code>
+        /// </example>
+        public static bool SetExceptionAndRethrow(this Operation operation, Exception exception)
+        {
+            operation.SetException(exception);
+            return false;
+        }
+    }
+}

--- a/test/SerilogTimings.Tests/OperationEnrichmentTests.cs
+++ b/test/SerilogTimings.Tests/OperationEnrichmentTests.cs
@@ -1,0 +1,166 @@
+﻿using System;
+using System.CodeDom;
+using System.Linq;
+using Serilog.Core;
+using Serilog.Events;
+using SerilogTimings.Extensions;
+using SerilogTimings.Tests.Support;
+using Xunit;
+
+namespace SerilogTimings.Tests
+{
+    public class OperationEnrichmentTests
+    {
+        private static void AssertScalarPropertyOfSingleEvent<T>(CollectingLogger logger, string propertyName, T expected)
+        {
+            var ev = Assert.Single(logger.Events);
+            Assert.True(ev.Properties.TryGetValue(propertyName, out var value));
+            Assert.Equal(
+                expected,
+                Assert.IsType<T>(Assert.IsType<ScalarValue>(value).Value)
+                );
+        }
+
+        [Fact]
+        public void AbandonRecordsAddedProperty()
+        {
+            var logger = new CollectingLogger();
+            var op = logger.Logger.BeginOperation("Test");
+            op.EnrichWith("Value", 42);
+            op.Dispose();
+            AssertScalarPropertyOfSingleEvent(logger, "Value", 42);
+        }
+
+        [Fact]
+        public void CompleteRecordsAddedProperty()
+        {
+            var logger = new CollectingLogger();
+            var op = logger.Logger.BeginOperation("Test");
+            op.EnrichWith("Value", 42);
+            op.Complete();
+            AssertScalarPropertyOfSingleEvent(logger, "Value", 42);
+        }
+
+        [Fact]
+        public void CompleteOverridesAddedProperty()
+        {
+            var logger = new CollectingLogger();
+            var op = logger.Logger.BeginOperation("Test");
+            op.EnrichWith("Value", 42);
+            op.Complete("Value", 43);
+            AssertScalarPropertyOfSingleEvent(logger, "Value", 43);
+        }
+
+        [Fact]
+        public void AbandonRecordsPropertyAddedViaEnricher()
+        {
+            var logger = new CollectingLogger();
+            var op = logger.Logger.BeginOperation("Test");
+            op.EnrichWith(new Enricher("Value", 42));
+            op.Dispose();
+            AssertScalarPropertyOfSingleEvent(logger, "Value", 42);
+        }
+
+        [Fact]
+        public void CompleteRecordsPropertyAddedViaEnricher()
+        {
+            var logger = new CollectingLogger();
+            var op = logger.Logger.BeginOperation("Test");
+            op.EnrichWith(new Enricher("Value", 42));
+            op.Complete();
+            AssertScalarPropertyOfSingleEvent(logger, "Value", 42);
+        }
+
+        [Fact]
+        public void OnceCanceledDisposeDoesNotInvokeEnricher()
+        {
+            var enricher = new Enricher(null, null);
+            var logger = new CollectingLogger();
+            var op = logger.Logger.BeginOperation("Test");
+            op.EnrichWith(enricher);
+            op.Cancel();
+            op.Dispose();
+            Assert.False(enricher.WasCalled);
+        }
+
+        [Fact]
+        public void OnceCanceledCompleteDoesNotInvokeEnricher()
+        {
+            var enricher = new Enricher(null, null);
+            var logger = new CollectingLogger();
+            var op = logger.Logger.BeginOperation("Test");
+            op.EnrichWith(enricher);
+            op.Cancel();
+            op.Complete();
+            op.Dispose();
+            Assert.False(enricher.WasCalled);
+        }
+
+        [Fact]
+        public void AbandonRecordsPropertiesAddedViaEnrichers()
+        {
+            var logger = new CollectingLogger();
+            var op = logger.Logger.BeginOperation("Test");
+            op.EnrichWith(new ILogEventEnricher[] {
+                new Enricher("Question", "unknown"),
+                new Enricher("Answer", 42)
+            });
+            op.Dispose();
+            AssertScalarPropertyOfSingleEvent(logger, "Question", "unknown");
+            AssertScalarPropertyOfSingleEvent(logger, "Answer", 42);
+        }
+
+        [Fact]
+        public void CompleteRecordsPropertiesAddedViaEnrichers()
+        {
+            var logger = new CollectingLogger();
+            var op = logger.Logger.BeginOperation("Test");
+            op.EnrichWith(new ILogEventEnricher[] {
+                new Enricher("Question", "unknown"),
+                new Enricher("Answer", 42)
+            });
+            op.Complete();
+            AssertScalarPropertyOfSingleEvent(logger, "Question", "unknown");
+            AssertScalarPropertyOfSingleEvent(logger, "Answer", 42);
+        }
+
+        [Fact]
+        public void PropertyBonanza()
+        {
+            var logger = new CollectingLogger();
+            logger.Logger
+                .BeginOperation("Test")
+                .EnrichWith(new ILogEventEnricher[] {
+                    new Enricher("Question", "unknown"),
+                    new Enricher("Answer", 42)
+                })
+                .EnrichWith(new Enricher("Don't", "panic"))
+                .EnrichWith("And bring", "towel")
+                .Complete();
+            AssertScalarPropertyOfSingleEvent(logger, "Question", "unknown");
+            AssertScalarPropertyOfSingleEvent(logger, "Answer", 42);
+            AssertScalarPropertyOfSingleEvent(logger, "Don't", "panic");
+            AssertScalarPropertyOfSingleEvent(logger, "And bring", "towel");
+        }
+
+        private class Enricher : ILogEventEnricher
+        {
+            private string _propertyName;
+            private object _value;
+
+            public Enricher(string propertyName, object value)
+            {
+                _propertyName = propertyName;
+                _value = value;
+            }
+
+            public void Enrich(LogEvent logEvent, ILogEventPropertyFactory propertyFactory)
+            {
+                WasCalled = true;
+                logEvent.AddPropertyIfAbsent(propertyFactory.CreateProperty(_propertyName, _value));
+            }
+
+            public bool WasCalled { get; private set; }
+        }
+    }
+}


### PR DESCRIPTION
Adds:

* `Operation.EnrichWith` (similar set of overloads as in `ILogger.ForContext`)
* `Operation.SetException`
* `Operation.SetExceptionAndRethrow` extension method to be used in exception filters (see https://www.thomaslevesque.com/2015/06/21/exception-filters-in-c-6/)