### PR TITLE
Adding Complete overloads to achieve symmetry with EnrichWith

### DIFF
--- a/src/SerilogTimings/OperationExtensions.cs
+++ b/src/SerilogTimings/OperationExtensions.cs
@@ -13,6 +13,8 @@
 // limitations under the License.
 
 using System;
+using System.Collections.Generic;
+using Serilog.Core;
 
 namespace SerilogTimings
 {
@@ -49,5 +51,25 @@ namespace SerilogTimings
             operation.SetException(exception);
             return false;
         }
+
+        /// <summary>
+        /// Complete the timed operation enriching it with provided enricher.
+        /// </summary>
+        /// <param name="operation">Operation to enrich and complete.</param>
+        /// <param name="enricher">Enricher that applies in the context.</param>
+        /// <seealso cref="Operation.Complete()"/>
+        /// <seealso cref="Operation.EnrichWith(ILogEventEnricher)"/>
+        public static void Complete(this Operation operation, ILogEventEnricher enricher)
+            => operation.EnrichWith(enricher).Complete();
+
+        /// <summary>
+        /// Complete the timed operation enriching it with provided enrichers.
+        /// </summary>
+        /// <param name="operation">Operation to enrich and complete.</param>
+        /// <param name="enrichers">Enrichers that apply in the context.</param>
+        /// <seealso cref="Operation.Complete()"/>
+        /// <seealso cref="Operation.EnrichWith(IEnumerable{ILogEventEnricher})"/>
+        public static void Complete(this Operation operation, IEnumerable<ILogEventEnricher> enrichers)
+            => operation.EnrichWith(enrichers).Complete();
     }
 }

--- a/test/SerilogTimings.Tests/OperationEnrichmentTests.cs
+++ b/test/SerilogTimings.Tests/OperationEnrichmentTests.cs
@@ -123,6 +123,28 @@ namespace SerilogTimings.Tests
         }
 
         [Fact]
+        public void CompleteOverloadWithEnricherRecordsPropertyAddedViaEnricher()
+        {
+            var logger = new CollectingLogger();
+            var op = logger.Logger.BeginOperation("Test");
+            op.Complete(new Enricher("Value", 42));
+            AssertScalarPropertyOfSingleEvent(logger, "Value", 42);
+        }
+
+        [Fact]
+        public void CompleteOverloadWithEnrichersRecordsPropertiesAddedViaEnrichers()
+        {
+            var logger = new CollectingLogger();
+            var op = logger.Logger.BeginOperation("Test");
+            op.Complete(new ILogEventEnricher[] {
+                new Enricher("Question", "unknown"),
+                new Enricher("Answer", 42)
+            });
+            AssertScalarPropertyOfSingleEvent(logger, "Question", "unknown");
+            AssertScalarPropertyOfSingleEvent(logger, "Answer", 42);
+        }
+
+        [Fact]
         public void PropertyBonanza()
         {
             var logger = new CollectingLogger();


### PR DESCRIPTION
A little more features for #8:

* `Operation.Complete(ILogEventEnricher enricher)`
* `Operation.Complete(IEnumerable<ILogEventEnricher> enrichers)`