### PR TITLE
Adding explicit Abandon method

### DIFF
--- a/src/SerilogTimings/Operation.cs
+++ b/src/SerilogTimings/Operation.cs
@@ -151,6 +151,17 @@ namespace SerilogTimings
         }
 
         /// <summary>
+        /// Abandon the timed operation. This will write the event and elapsed time to the log.
+        /// </summary>
+        public void Abandon()
+        {
+            if (_completionBehaviour == CompletionBehaviour.Silent)
+                return;
+
+            Write(_target, _abandonmentLevel, OutcomeAbandoned);
+        }
+
+        /// <summary>
         /// Cancel the timed operation. After calling, no event will be recorded either through
         /// completion or disposal.
         /// </summary>

--- a/src/SerilogTimings/OperationExtensions.cs
+++ b/src/SerilogTimings/OperationExtensions.cs
@@ -71,5 +71,47 @@ namespace SerilogTimings
         /// <seealso cref="Operation.EnrichWith(IEnumerable{ILogEventEnricher})"/>
         public static void Complete(this Operation operation, IEnumerable<ILogEventEnricher> enrichers)
             => operation.EnrichWith(enrichers).Complete();
+
+        /// <summary>
+        /// Abandon the timed operation with an included result value.
+        /// </summary>
+        /// <param name="operation">Operation to enrich and abandon.</param>
+        /// <param name="resultPropertyName">The name for the property to attach to the event.</param>
+        /// <param name="result">The result value.</param>
+        /// <param name="destructureObjects">If true, the property value will be destructured (serialized).</param>
+        /// <seealso cref="Operation.Abandon()"/>
+        /// <seealso cref="Operation.EnrichWith(string,object,bool)"/>
+        public static void Abandon(this Operation operation, string resultPropertyName, object result, bool destructureObjects = false)
+            => operation.EnrichWith(resultPropertyName, result, destructureObjects).Abandon();
+
+        /// <summary>
+        /// Abandon the timed operation enriching it with provided enricher.
+        /// </summary>
+        /// <param name="operation">Operation to enrich and abandon.</param>
+        /// <param name="enricher">Enricher that applies in the context.</param>
+        /// <seealso cref="Operation.Abandon()"/>
+        /// <seealso cref="Operation.EnrichWith(ILogEventEnricher)"/>
+        public static void Abandon(this Operation operation, ILogEventEnricher enricher)
+            => operation.EnrichWith(enricher).Abandon();
+
+        /// <summary>
+        /// Abandon the timed operation enriching it with provided enrichers.
+        /// </summary>
+        /// <param name="operation">Operation to enrich and abandon.</param>
+        /// <param name="enrichers">Enrichers that apply in the context.</param>
+        /// <seealso cref="Operation.Abandon()"/>
+        /// <seealso cref="Operation.EnrichWith(IEnumerable{ILogEventEnricher})"/>
+        public static void Abandon(this Operation operation, IEnumerable<ILogEventEnricher> enrichers)
+            => operation.EnrichWith(enrichers).Abandon();
+
+        /// <summary>
+        /// Abandon the timed operation with an included exception.
+        /// </summary>
+        /// <param name="operation">Operation to enrich and abandon.</param>
+        /// <param name="exception">Enricher related to the event.</param>
+        /// <seealso cref="Operation.Abandon()"/>
+        /// <seealso cref="Operation.SetException(Exception)"/>
+        public static void Abandon(this Operation operation, Exception exception)
+            => operation.SetException(exception).Abandon();
     }
 }

--- a/src/SerilogTimings/OperationExtensions.cs
+++ b/src/SerilogTimings/OperationExtensions.cs
@@ -13,6 +13,8 @@
 // limitations under the License.
 
 using System;
+using System.Collections.Generic;
+using Serilog.Core;
 
 namespace SerilogTimings
 {
@@ -49,5 +51,25 @@ namespace SerilogTimings
             operation.SetException(exception);
             return false;
         }
+
+        /// <summary>
+        /// Complete the timed operation enriching it with provided enricher.
+        /// </summary>
+        /// <param name="operation">Operation to enrich and complete.</param>
+        /// <param name="enricher">Enricher that applies in the context.</param>
+        /// <seealso cref="Operation.Complete()"/>
+        /// <seealso cref="Operation.EnrichWith(ILogEventEnricher)"/>
+        public static void Complete(this Operation operation, ILogEventEnricher enricher)
+            => operation.EnrichWith(enricher).Complete();
+
+        /// <summary>
+        /// Complete the timed operation enriching it with provided enrichers.
+        /// </summary>
+        /// <param name="operation">Operation to enrich and complete.</param>
+        /// <param name="enrichers">Enrichers that apply in the context.</param>
+        /// <seealso cref="Operation.Complete()"/>
+        /// <seealso cref="Operation.EnrichWith(IEnumerable{ILogEventEnricher})"/>
+        public static void Complete(this Operation operation, IEnumerable<ILogEventEnricher> enrichers)
+            => operation.EnrichWith(enrichers).Complete();
     }
 }

--- a/test/SerilogTimings.Tests/OperationEnrichmentTests.cs
+++ b/test/SerilogTimings.Tests/OperationEnrichmentTests.cs
@@ -123,6 +123,28 @@ namespace SerilogTimings.Tests
         }
 
         [Fact]
+        public void CompleteOverloadWithEnricherRecordsPropertyAddedViaEnricher()
+        {
+            var logger = new CollectingLogger();
+            var op = logger.Logger.BeginOperation("Test");
+            op.Complete(new Enricher("Value", 42));
+            AssertScalarPropertyOfSingleEvent(logger, "Value", 42);
+        }
+
+        [Fact]
+        public void CompleteOverloadWithEnrichersRecordsPropertiesAddedViaEnrichers()
+        {
+            var logger = new CollectingLogger();
+            var op = logger.Logger.BeginOperation("Test");
+            op.Complete(new ILogEventEnricher[] {
+                new Enricher("Question", "unknown"),
+                new Enricher("Answer", 42)
+            });
+            AssertScalarPropertyOfSingleEvent(logger, "Question", "unknown");
+            AssertScalarPropertyOfSingleEvent(logger, "Answer", 42);
+        }
+
+        [Fact]
         public void PropertyBonanza()
         {
             var logger = new CollectingLogger();

--- a/test/SerilogTimings.Tests/OperationTests.cs
+++ b/test/SerilogTimings.Tests/OperationTests.cs
@@ -126,5 +126,40 @@ namespace SerilogTimings.Tests
             var sourceContext = (logger.Events.Single().Properties["SourceContext"] as ScalarValue).Value;
             Assert.Equal(sourceContext, typeof(OperationTests).FullName);
         }
+
+        [Fact]
+        public void CompleteRecordsOperationId()
+        {
+            var innerLogger = new CollectingLogger();
+            var logger = new LoggerConfiguration()
+                .WriteTo.Logger(innerLogger.Logger)
+                .Enrich.FromLogContext()
+                .CreateLogger();
+            
+            var op = logger.BeginOperation("Test");
+            op.Complete();
+            Assert.True(
+                Assert.Single(innerLogger.Events)
+                    .Properties.ContainsKey(nameof(Operation.Properties.OperationId))
+            );
+        }
+
+        [Fact]
+        public void AbandonRecordsOperationId()
+        {
+            var innerLogger = new CollectingLogger();
+            var logger = new LoggerConfiguration()
+                .WriteTo.Logger(innerLogger.Logger)
+                .Enrich.FromLogContext()
+                .CreateLogger();
+            
+            var op = logger.BeginOperation("Test");
+            op.Dispose();
+            Assert.True(
+                Assert.Single(innerLogger.Events)
+                    .Properties.ContainsKey(nameof(Operation.Properties.OperationId))
+            );
+        }
+
     }
 }

--- a/test/SerilogTimings.Tests/OperationTests.cs
+++ b/test/SerilogTimings.Tests/OperationTests.cs
@@ -1,4 +1,5 @@
-﻿using System.Linq;
+﻿using System;
+using System.Linq;
 using Serilog;
 using Serilog.Events;
 using SerilogTimings.Extensions;
@@ -9,14 +10,34 @@ namespace SerilogTimings.Tests
 {
     public class OperationTests
     {
+        private const string OutcomeCompleted = "completed";
+        private const string OutcomeAbandoned = "abandoned";
+
+        private static LogEvent AssertSingleCompletionEvent(CollectingLogger logger, LogEventLevel expectedLevel,
+            string expectedOutcome)
+        {
+            T GetScalarPropertyValue<T>(LogEvent e, string key)
+            {
+                Assert.True(e.Properties.TryGetValue(key, out var value));
+                return Assert.IsType<T>(Assert.IsType<ScalarValue>(value).Value);
+            }
+
+            var ev = Assert.Single(logger.Events);
+            Assert.NotNull(ev);
+            Assert.Equal(expectedLevel, ev.Level);
+
+            Assert.Equal(expectedOutcome, GetScalarPropertyValue<string>(ev, nameof(Operation.Properties.Outcome)));
+            GetScalarPropertyValue<double>(ev, nameof(Operation.Properties.Elapsed));
+            return ev;
+        }
+
         [Fact]
         public void DisposeRecordsCompletionOfTimings()
         {
             var logger = new CollectingLogger();
             var op = logger.Logger.TimeOperation("Test");
             op.Dispose();
-            Assert.Equal(1, logger.Events.Count);
-            Assert.Equal(LogEventLevel.Information, logger.Events.Single().Level);
+            AssertSingleCompletionEvent(logger, LogEventLevel.Information, OutcomeCompleted);
         }
 
         [Fact]
@@ -25,11 +46,10 @@ namespace SerilogTimings.Tests
             var logger = new CollectingLogger();
             var op = logger.Logger.BeginOperation("Test");
             op.Complete();
-            Assert.Equal(1, logger.Events.Count);
-            Assert.Equal(LogEventLevel.Information, logger.Events.Single().Level);
+            AssertSingleCompletionEvent(logger, LogEventLevel.Information, OutcomeCompleted);
 
             op.Dispose();
-            Assert.Equal(1, logger.Events.Count);
+            Assert.Single(logger.Events);
         }
 
         [Fact]
@@ -38,11 +58,10 @@ namespace SerilogTimings.Tests
             var logger = new CollectingLogger();
             var op = logger.Logger.BeginOperation("Test");
             op.Dispose();
-            Assert.Equal(1, logger.Events.Count);
-            Assert.Equal(LogEventLevel.Warning, logger.Events.Single().Level);
+            AssertSingleCompletionEvent(logger, LogEventLevel.Warning, OutcomeAbandoned);
 
             op.Dispose();
-            Assert.Equal(1, logger.Events.Count);
+            Assert.Single(logger.Events);
         }
 
         [Fact]
@@ -51,7 +70,7 @@ namespace SerilogTimings.Tests
             var logger = new CollectingLogger();
             var op = logger.Logger.BeginOperation("Test");
             op.Complete("Value", 42);
-            Assert.Equal(1, logger.Events.Count);
+            Assert.Single(logger.Events);
             Assert.True(logger.Events.Single().Properties.ContainsKey("Value"));
         }
 
@@ -62,7 +81,7 @@ namespace SerilogTimings.Tests
             var op = logger.Logger.BeginOperation("Test");
             op.Cancel();
             op.Dispose();
-            Assert.Equal(0, logger.Events.Count);
+            Assert.Empty(logger.Events);
         }
 
         [Fact]
@@ -73,7 +92,7 @@ namespace SerilogTimings.Tests
             op.Cancel();
             op.Complete();
             op.Dispose();
-            Assert.Equal(0, logger.Events.Count);
+            Assert.Empty(logger.Events);
         }
 
         [Fact]
@@ -82,8 +101,7 @@ namespace SerilogTimings.Tests
             var logger = new CollectingLogger();
             var op = logger.Logger.OperationAt(LogEventLevel.Error).Time("Test");
             op.Dispose();
-            Assert.Equal(1, logger.Events.Count);
-            Assert.Equal(LogEventLevel.Error, logger.Events.Single().Level);
+            AssertSingleCompletionEvent(logger, LogEventLevel.Error, OutcomeCompleted);
         }
 
         [Fact]
@@ -92,8 +110,7 @@ namespace SerilogTimings.Tests
             var logger = new CollectingLogger();
             var op = logger.Logger.OperationAt(LogEventLevel.Error).Begin("Test");
             op.Dispose();
-            Assert.Equal(1, logger.Events.Count);
-            Assert.Equal(LogEventLevel.Error, logger.Events.Single().Level);
+            AssertSingleCompletionEvent(logger, LogEventLevel.Error, OutcomeAbandoned);
         }
 
         [Fact]
@@ -102,8 +119,7 @@ namespace SerilogTimings.Tests
             var logger = new CollectingLogger();
             var op = logger.Logger.OperationAt(LogEventLevel.Error, LogEventLevel.Fatal).Begin("Test");
             op.Dispose();
-            Assert.Equal(1, logger.Events.Count);
-            Assert.Equal(LogEventLevel.Fatal, logger.Events.Single().Level);
+            AssertSingleCompletionEvent(logger, LogEventLevel.Fatal, OutcomeAbandoned);
         }
 
         [Fact]


### PR DESCRIPTION
* `Operation.Abandon()`
* The whole list of "overloads" which makes more sense after merging #31 

Also, a little test refactoring to make asserts a bit more idiomatic.