### PR TITLE
Added ability to log timings as Warnings for operations that take longer than expected

### DIFF
--- a/src/SerilogTimings/Operation.cs
+++ b/src/SerilogTimings/Operation.cs
@@ -303,7 +303,7 @@ namespace SerilogTimings
         }
         
         /// <summary>
-        /// Logs all operations that take longer than `warningThreshold` as Warnings even if they completed successfully.
+        /// Logs all operations that take longer than `warningThreshold` as Warnings even if they complete successfully.
         /// </summary>
         /// <param name="warningThreshold">Enricher that applies in the context.</param>
         /// <returns>Same <see cref="Operation"/>.</returns>

--- a/src/SerilogTimings/Operation.cs
+++ b/src/SerilogTimings/Operation.cs
@@ -309,7 +309,7 @@ namespace SerilogTimings
         /// <returns>Same <see cref="Operation"/>.</returns>
         public Operation WithWarningThreshold(TimeSpan warningThreshold)
         {
-            _warningThreshold = warningThreshold ;
+            _warningThreshold = warningThreshold;
             return this;
         }
     }

--- a/test/SerilogTimings.Tests/OperationTests.cs
+++ b/test/SerilogTimings.Tests/OperationTests.cs
@@ -1,4 +1,6 @@
-﻿using System.Linq;
+﻿using System;
+using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using Serilog;
 using Serilog.Events;
@@ -269,6 +271,23 @@ namespace SerilogTimings.Tests
             Assert.NotEqual(second, third);
             Assert.Equal(third, fourth);
             Assert.Equal(fourth, fifth);
+        }
+        
+        [Fact]
+        public async Task LongOperationsAreLoggedAsWarnings()
+        {
+            var operationDuration = TimeSpan.FromMilliseconds(100);
+            
+            var logger = new CollectingLogger();
+            var op = logger.Logger
+                .BeginOperation("Test")
+                .WithWarningThreshold(operationDuration);
+            
+            await Task.Delay(operationDuration + operationDuration);
+            
+            op.Complete();
+
+            Assert.Equal(LogEventLevel.Warning, logger.Events.Single().Level);
         }
     }
 }

--- a/test/SerilogTimings.Tests/OperationTests.cs
+++ b/test/SerilogTimings.Tests/OperationTests.cs
@@ -307,5 +307,23 @@ namespace SerilogTimings.Tests
 
             Assert.Equal(LogEventLevel.Error, logger.Events.Single().Level);
         }
+        
+        [Fact]
+        public async Task LongOperationsAreLoggedAsWarningsWithDebug()
+        {
+            var operationDuration = TimeSpan.FromMilliseconds(100);
+
+            var logger = new CollectingLogger();
+            var op = logger.Logger
+                .OperationAt(LogEventLevel.Debug)  // Debug is off by default...
+                .Begin("Test")
+                .WithWarningThreshold(operationDuration); // ... seems like this should be emitted?
+
+            await Task.Delay(operationDuration + operationDuration);
+
+            op.Complete();
+
+            Assert.Equal(LogEventLevel.Warning, logger.Events.Single().Level);
+        }
     }
 }

--- a/test/SerilogTimings.Tests/OperationTests.cs
+++ b/test/SerilogTimings.Tests/OperationTests.cs
@@ -289,5 +289,23 @@ namespace SerilogTimings.Tests
 
             Assert.Equal(LogEventLevel.Warning, logger.Events.Single().Level);
         }
+        
+        [Fact]
+        public async Task LongOperationsDoNotLowerTheOverallLoggingLevel()
+        {
+            var operationDuration = TimeSpan.FromMilliseconds(100);
+            
+            var logger = new CollectingLogger();
+            var op = logger.Logger
+                .OperationAt(LogEventLevel.Information, LogEventLevel.Error)
+                .Begin("Test")
+                .WithWarningThreshold(operationDuration);
+            
+            await Task.Delay(operationDuration + operationDuration);
+            
+            op.Abandon();
+
+            Assert.Equal(LogEventLevel.Error, logger.Events.Single().Level);
+        }
     }
 }


### PR DESCRIPTION
Stole the idea from @uglybugger :).   This extension helps easily identify code paths that are slower than expected. 