### PR TITLE
Added ability to log timings as Warnings for operations that take longer than expected

### DIFF
--- a/src/SerilogTimings/Configuration/LevelledOperation.cs
+++ b/src/SerilogTimings/Configuration/LevelledOperation.cs
@@ -28,12 +28,14 @@ namespace SerilogTimings.Configuration
         readonly ILogger? _logger;
         readonly LogEventLevel _completion;
         readonly LogEventLevel _abandonment;
+        private readonly TimeSpan? _warningThreshold;
 
-        internal LevelledOperation(ILogger logger, LogEventLevel completion, LogEventLevel abandonment)
+        internal LevelledOperation(ILogger logger, LogEventLevel completion, LogEventLevel abandonment, TimeSpan? warningThreshold = null)
         {
             _logger = logger ?? throw new ArgumentNullException(nameof(logger));
             _completion = completion;
             _abandonment = abandonment;
+            _warningThreshold = warningThreshold;
         }
 
         LevelledOperation(Operation cachedResult)
@@ -59,7 +61,7 @@ namespace SerilogTimings.Configuration
         /// <returns>An <see cref="Operation"/> object.</returns>
         public Operation Begin(string messageTemplate, params object[] args)
         {
-            return _cachedResult ?? new Operation(_logger!, messageTemplate, args, CompletionBehaviour.Abandon, _completion, _abandonment);
+            return _cachedResult ?? new Operation(_logger!, messageTemplate, args, CompletionBehaviour.Abandon, _completion, _abandonment, _warningThreshold);
         }
 
         /// <summary>
@@ -71,7 +73,7 @@ namespace SerilogTimings.Configuration
         /// <returns>An <see cref="Operation"/> object.</returns>
         public IDisposable Time(string messageTemplate, params object[] args)
         {
-            return _cachedResult ?? new Operation(_logger!, messageTemplate, args, CompletionBehaviour.Complete, _completion, _abandonment);
+            return _cachedResult ?? new Operation(_logger!, messageTemplate, args, CompletionBehaviour.Complete, _completion, _abandonment, _warningThreshold);
         }
     }
 }

--- a/src/SerilogTimings/Configuration/LevelledOperation.cs
+++ b/src/SerilogTimings/Configuration/LevelledOperation.cs
@@ -28,7 +28,7 @@ namespace SerilogTimings.Configuration
         readonly ILogger? _logger;
         readonly LogEventLevel _completion;
         readonly LogEventLevel _abandonment;
-        private readonly TimeSpan? _warningThreshold;
+        readonly TimeSpan? _warningThreshold;
 
         internal LevelledOperation(ILogger logger, LogEventLevel completion, LogEventLevel abandonment, TimeSpan? warningThreshold = null)
         {

--- a/src/SerilogTimings/Extensions/LoggerOperationExtensions.cs
+++ b/src/SerilogTimings/Extensions/LoggerOperationExtensions.cs
@@ -50,7 +50,7 @@ namespace SerilogTimings.Extensions
         {
             return new Operation(logger, messageTemplate, args, CompletionBehaviour.Abandon, LogEventLevel.Information, LogEventLevel.Warning);
         }
-
+        
         /// <summary>
         /// Configure the logging levels used for completion and abandonment events.
         /// </summary>
@@ -58,10 +58,11 @@ namespace SerilogTimings.Extensions
         /// <param name="completion">The level of the event to write on operation completion.</param>
         /// <param name="abandonment">The level of the event to write on operation abandonment; if not
         /// specified, the <paramref name="completion"/> level will be used.</param>
+        /// <param name="warningThreshold">The threshold which determines whether the timing will be recorded as warning</param>
         /// <returns>An object from which timings with the configured levels can be made.</returns>
         /// <remarks>If neither <paramref name="completion"/> nor <paramref name="abandonment"/> is enabled
         /// on the logger at the time of the call, a no-op result is returned.</remarks>
-        public static LevelledOperation OperationAt(this ILogger logger, LogEventLevel completion, LogEventLevel? abandonment = null)
+        public static LevelledOperation OperationAt(this ILogger logger, LogEventLevel completion, LogEventLevel? abandonment = null, TimeSpan? warningThreshold = null)
         {
             if (logger == null) throw new ArgumentNullException(nameof(logger));
 
@@ -72,7 +73,7 @@ namespace SerilogTimings.Extensions
                 return LevelledOperation.None;
             }
 
-            return new LevelledOperation(logger, completion, appliedAbandonment);
+            return new LevelledOperation(logger, completion, appliedAbandonment, warningThreshold);
         }
     }
 }


### PR DESCRIPTION
Iteration on the idea described [here](https://github.com/nblumhardt/serilog-timings/pull/41).  The API now allows the warning threshold to be specified together with the logging levels.