### PR TITLE
Annotate methods with `[MessageTemplateFormatMethod]`

### DIFF
--- a/src/SerilogTimings/Configuration/LevelledOperation.cs
+++ b/src/SerilogTimings/Configuration/LevelledOperation.cs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 using Serilog;
+using Serilog.Core;
 using Serilog.Events;
 
 namespace SerilogTimings.Configuration
@@ -59,6 +60,7 @@ namespace SerilogTimings.Configuration
         /// <param name="args">Arguments to the log message. These will be stored and captured only when the
         /// operation completes, so do not pass arguments that are mutated during the operation.</param>
         /// <returns>An <see cref="Operation"/> object.</returns>
+        [MessageTemplateFormatMethod("messageTemplate")]
         public Operation Begin(string messageTemplate, params object[] args)
         {
             return _cachedResult ?? new Operation(_logger!, messageTemplate, args, CompletionBehaviour.Abandon, _completion, _abandonment, _warningThreshold);
@@ -71,6 +73,7 @@ namespace SerilogTimings.Configuration
         /// <param name="args">Arguments to the log message. These will be stored and captured only when the
         /// operation completes, so do not pass arguments that are mutated during the operation.</param>
         /// <returns>An <see cref="Operation"/> object.</returns>
+        [MessageTemplateFormatMethod("messageTemplate")]
         public IDisposable Time(string messageTemplate, params object[] args)
         {
             return _cachedResult ?? new Operation(_logger!, messageTemplate, args, CompletionBehaviour.Complete, _completion, _abandonment, _warningThreshold);

--- a/src/SerilogTimings/Extensions/LoggerOperationExtensions.cs
+++ b/src/SerilogTimings/Extensions/LoggerOperationExtensions.cs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 using Serilog;
+using Serilog.Core;
 using Serilog.Events;
 using SerilogTimings.Configuration;
 
@@ -31,6 +32,7 @@ namespace SerilogTimings.Extensions
         /// <param name="args">Arguments to the log message. These will be stored and captured only when the
         /// operation completes, so do not pass arguments that are mutated during the operation.</param>
         /// <returns>An <see cref="Operation"/> object.</returns>
+        [MessageTemplateFormatMethod("messageTemplate")]
         public static IDisposable TimeOperation(this ILogger logger, string messageTemplate, params object[] args)
         {
             return new Operation(logger, messageTemplate, args, CompletionBehaviour.Complete, LogEventLevel.Information, LogEventLevel.Warning);
@@ -45,6 +47,7 @@ namespace SerilogTimings.Extensions
         /// <param name="args">Arguments to the log message. These will be stored and captured only when the
         /// operation completes, so do not pass arguments that are mutated during the operation.</param>
         /// <returns>An <see cref="Operation"/> object.</returns>
+        [MessageTemplateFormatMethod("messageTemplate")]
         public static Operation BeginOperation(this ILogger logger, string messageTemplate, params object[] args)
         {
             return new Operation(logger, messageTemplate, args, CompletionBehaviour.Abandon, LogEventLevel.Information, LogEventLevel.Warning);

--- a/src/SerilogTimings/Operation.cs
+++ b/src/SerilogTimings/Operation.cs
@@ -98,6 +98,7 @@ namespace SerilogTimings
         /// <param name="args">Arguments to the log message. These will be stored and captured only when the
         /// operation completes, so do not pass arguments that are mutated during the operation.</param>
         /// <returns>An <see cref="Operation"/> object.</returns>
+        [MessageTemplateFormatMethod("messageTemplate")]
         public static Operation Begin(string messageTemplate, params object[] args)
         {
             return Log.Logger.BeginOperation(messageTemplate, args);
@@ -110,6 +111,7 @@ namespace SerilogTimings
         /// <param name="args">Arguments to the log message. These will be stored and captured only when the
         /// operation completes, so do not pass arguments that are mutated during the operation.</param>
         /// <returns>An <see cref="Operation"/> object.</returns>
+        [MessageTemplateFormatMethod("messageTemplate")]
         public static IDisposable Time(string messageTemplate, params object[] args)
         {
             return Log.Logger.TimeOperation(messageTemplate, args);


### PR DESCRIPTION
Analyzers such as SerilogAnalyzer and IDEs such as Jetbrains Rider use this attribute to determine which methods to analyze and generate warnings for (and highlight message template literals).